### PR TITLE
Add generate regear endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ const cors = require('cors');
 const errorHandler = require('./errors/errorHandler');
 const notFound = require('./errors/notFound');
 const regearsRouter = require('./regears/regears.router');
+const generateRegearRequestRouter = require('./generateRegearRequest/generateRegearRequest.router');
 
 const app = express();
 
@@ -15,6 +16,7 @@ app.use(cors());
 app.use(express.json());
 
 app.use('/regears', regearsRouter);
+app.use('/generateRegearRequest', generateRegearRequestRouter);
 app.use(
   '/',
   createProxyMiddleware({

--- a/src/generateRegearRequest/generateRegearRequest.controller.js
+++ b/src/generateRegearRequest/generateRegearRequest.controller.js
@@ -1,0 +1,95 @@
+const gear = require('../data/gear.json');
+const { generateTier, getItemName } = require('../utils/utils');
+
+// I need these objects available globally in order to control the order of my res.locals.regearReq object.
+// this is important for when I map it to my model in my Spring Boot application.
+const shortedNames = [];
+const itemLevels = {};
+
+function generateEnglishName(req, res, next) {
+  const { main_hand, head_piece, chest_armor, shoes } = req.body.data;
+  const gearArr = [main_hand, head_piece, chest_armor, shoes];
+
+  const englishNames = [];
+  for (const gearPiece of gearArr) {
+    const itemDescription = gear.find((item) => item.UniqueName == gearPiece);
+    englishNames.push(itemDescription.LocalizedNames['EN-US']);
+  }
+
+  for (let fullName of englishNames) {
+    const shortenedName = getItemName(fullName);
+    shortedNames.push(shortenedName);
+  }
+
+  next();
+}
+
+function generateItemLevels(req, res, next) {
+  const { main_hand, head_piece, chest_armor, shoes } = req.body.data;
+
+  itemLevels[main_hand] = generateTier(main_hand);
+  itemLevels[head_piece] = generateTier(head_piece);
+  itemLevels[chest_armor] = generateTier(chest_armor);
+  itemLevels[shoes] = generateTier(shoes);
+  next();
+}
+
+function generateNewResponseBody(req, res, next) {
+  const {
+    main_hand,
+    head_piece,
+    chest_armor,
+    shoes,
+    character_name,
+    event_id,
+    guild_name,
+    item_power,
+    time_of_death,
+  } = req.body.data;
+
+  res.locals.regearReq = {};
+
+  // set main_hand properties
+  res.locals.regearReq.main_hand = shortedNames[0];
+  res.locals.regearReq.main_tier = itemLevels[main_hand].itemLevel;
+  res.locals.regearReq.main_equivalent = itemLevels[main_hand].tierEquivalent;
+
+  // set head_gear properties
+  res.locals.regearReq.head_gear = shortedNames[1];
+  res.locals.regearReq.head_tier = itemLevels[head_piece].itemLevel;
+  res.locals.regearReq.head_equivalent = itemLevels[head_piece].tierEquivalent;
+
+  // set chest_gear properties
+  res.locals.regearReq.chest_gear = shortedNames[2];
+  res.locals.regearReq.chest_tier = itemLevels[chest_armor].itemLevel;
+  res.locals.regearReq.chest_equivalent =
+    itemLevels[chest_armor].tierEquivalent;
+
+  // set shoes properties
+  res.locals.regearReq.shoes = shortedNames[3];
+  res.locals.regearReq.shoes_tier = itemLevels[shoes].itemLevel;
+  res.locals.regearReq.shoes_equivalent = itemLevels[shoes].tierEquivalent;
+
+  // set remaining properties from original request body.
+  res.locals.regearReq.character_name = character_name;
+  res.locals.regearReq.event_id = event_id;
+  res.locals.regearReq.guild_name = guild_name;
+  res.locals.regearReq.item_power = item_power;
+  res.locals.regearReq.time_of_death = time_of_death;
+
+  next();
+}
+
+function create(req, res, next) {
+  const regearRequest = res.locals.regearReq;
+  res.status(201).json({ regearRequest });
+}
+
+module.exports = {
+  create: [
+    generateEnglishName,
+    generateItemLevels,
+    generateNewResponseBody,
+    create,
+  ],
+};

--- a/src/generateRegearRequest/generateRegearRequest.router.js
+++ b/src/generateRegearRequest/generateRegearRequest.router.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const controller = require('../generateRegearRequest/generateRegearRequest.controller');
+const methodNotAllowed = require('../errors/methodNotAllowed');
+
+router.route('/').post(controller.create).all(methodNotAllowed);
+
+module.exports = router;

--- a/src/regears/regears.controller.js
+++ b/src/regears/regears.controller.js
@@ -2,6 +2,7 @@ const service = require('./regears.service');
 const gear = require('../data/gear.json');
 const validGear = require('../data/validGear.json');
 const asyncErrorBoundary = require('../errors/asyncErrorBoundary');
+const { generateTier, getItemName } = require('../utils/utils');
 
 const validGuilds = ['Tidal', 'Tidal Surge', 'Ripple'];
 const minTier = 7;
@@ -20,29 +21,6 @@ const validProperties = [
 ];
 
 const armorTypes = ['CLOTH', 'LEATHER', 'PLATE'];
-
-function generateTier(itemSlot) {
-  const tier = parseInt(itemSlot.slice(1, 2));
-  const enchantment = parseInt(itemSlot.split('@')[1]);
-
-  let tierEquivalent = tier;
-  let itemLevel = tier;
-
-  if (!isNaN(enchantment)) {
-    tierEquivalent += enchantment;
-    itemLevel = `${tier}.${enchantment}`;
-  }
-
-  return {
-    tierEquivalent,
-    itemLevel,
-  };
-}
-
-function getItemName(itemFullName) {
-  const shortenedName = itemFullName.split(' ').slice(1).join(' ');
-  return shortenedName;
-}
 
 function hasData(req, res, next) {
   const { data } = req.body;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,27 @@
+function generateTier(itemSlot) {
+  const tier = parseInt(itemSlot.slice(1, 2));
+  const enchantment = parseInt(itemSlot.split('@')[1]);
+
+  let tierEquivalent = tier;
+  let itemLevel = tier;
+
+  if (!isNaN(enchantment)) {
+    tierEquivalent += enchantment;
+    itemLevel = `${tier}.${enchantment}`;
+  }
+
+  return {
+    tierEquivalent,
+    itemLevel,
+  };
+}
+
+function getItemName(itemFullName) {
+  const shortenedName = itemFullName.split(' ').slice(1).join(' ');
+  return shortenedName;
+}
+
+module.exports = {
+  generateTier,
+  getItemName,
+};


### PR DESCRIPTION
Create new endpoint for the Albion Regears client to point to when submitting a regear request.
This endpoint takes in the request body and retrieves additional information based on what is present, as well as modifying some of the provided values. 
It creates a new regearReq object containing plain English names, item levels, tier equivalencies, and all other relevant data needed in order to validate and post a successful regear request.